### PR TITLE
go back to star import, bump version to 0.2.2

### DIFF
--- a/ilpy/__init__.py
+++ b/ilpy/__init__.py
@@ -1,26 +1,3 @@
-from .wrapper import (
-    LinearConstraint,
-    LinearConstraints,
-    LinearObjective,
-    LinearSolver,
-    Preference,
-    QuadraticObjective,
-    Relation,
-    Sense,
-    Solution,
-    VariableType,
-)
+from .wrapper import *
 
-__version__ = "0.2.1"
-__all__ = [
-    "LinearConstraint",
-    "LinearConstraints",
-    "LinearObjective",
-    "LinearSolver",
-    "Preference",
-    "QuadraticObjective",
-    "Relation",
-    "Sense",
-    "Solution",
-    "VariableType",
-]
+__version__ = "0.2.2"

--- a/ilpy/wrapper.pyi
+++ b/ilpy/wrapper.pyi
@@ -20,6 +20,21 @@ class Relation(IntEnum):
     Equal = auto()
     GreaterEqual = auto()
 
+# cython appears to make these available as module-level constants as well
+Any = Preference.Any
+Scip = Preference.Scip
+Gurobi = Preference.Gurobi
+Cplex = Preference.Cplex
+Continuous = VariableType.Continuous
+Integer = VariableType.Integer
+Binary = VariableType.Binary
+Minimize = Sense.Minimize
+Maximize = Sense.Maximize
+Equal = Relation.Equal
+GreaterEqual = Relation.GreaterEqual
+LessEqual = Relation.LessEqual
+
+
 class Solution:
     def __init__(self, size: int) -> None: ...
     def __len__(self) -> int: ...


### PR DESCRIPTION
this reverts the [explicit import](https://github.com/funkelab/ilpy/pull/3/files#diff-4e2b7ab45b18d981592b5ba17d177f7b163ac36d3e1d12f4c29ce070338919ceR1) of names from wrapper back to the star import.  I didn't realize that Cython exports all enum *members* in addition to the enum namespaces, so #3 broke the ability to use `ilpy.Equal` instead of `ilpy.Relation.Equal`.  This fixes that and bumps the version for a new release