### PR TITLE
Use pyproject for everything but cython

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ pip install -e .[dev]
 
 > Only for maintainers
 
-bump the version in both `setup.py` and `__init__.py` (unless you later
-setup auto versioning), and commit it.  Then create an annotated tag with:
+Bump the version in `__init__.py` and commit it.
+
+Then create an annotated tag with:
 
 ```bash
 git tag -a vX.Y.Z -m "vX.Y.Z"

--- a/ilpy/__init__.py
+++ b/ilpy/__init__.py
@@ -1,3 +1,3 @@
 from .wrapper import *
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ dev = ["flake8", "pytest", "pytest-cov"]
 homepage = "https://github.com/funkelab/ilpy"
 repository = "https://github.com/funkelab/ilpy"
 
+[tool.setuptools]
+packages = ["ilpy"]
+package-data = { "ilpy" = ["py.typed", "*.pyi"] }
+
 [tool.setuptools.dynamic]
-version = {attr = "ilpy.__version__"}
-readme = {file = ["README.md"]}
+version = { attr = "ilpy.__version__" }
+readme = { file = ["README.md"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,26 @@
 [build-system]
 requires = ["setuptools", "Cython"]
 build-backend = "setuptools.build_meta"
+
+# https://peps.python.org/pep-0621/
+[project]
+name = "ilpy"
+description = "Python wrappers for popular MIP solvers."
+requires-python = ">=3.8"
+license = { text = "MIT" }
+authors = [{ email = "funkej@janelia.hhmi.org", name = "Jan Funke" }]
+dynamic = ["version", "readme"]
+dependencies = []
+
+# extras
+# https://peps.python.org/pep-0621/#dependencies-optional-dependencies
+[project.optional-dependencies]
+dev = ["flake8", "pytest", "pytest-cov"]
+
+[project.urls]
+homepage = "https://github.com/funkelab/ilpy"
+repository = "https://github.com/funkelab/ilpy"
+
+[tool.setuptools.dynamic]
+version = {attr = "ilpy.__version__"}
+readme = {file = ["README.md"]}

--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,7 @@ wrapper = Extension(
     language="c++",
 )
 
-setup(ext_modules=cythonize([wrapper]))
+setup(
+    ext_modules=cythonize([wrapper]),
+    package_data={"ilpy": ["py.typed", "*.pyi"]},
+)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,4 @@ wrapper = Extension(
     language="c++",
 )
 
-setup(
-    ext_modules=cythonize([wrapper]),
-    package_data={"ilpy": ["py.typed", "*.pyi"]},
-)
+setup(ext_modules=cythonize([wrapper]))

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 from setuptools.extension import Extension
 
 libraries = ["libscip"] if os.name == "nt" else ["scip"]
-include_dirs = ['ilpy/impl']
+include_dirs = ["ilpy/impl"]
 library_dirs = []
 compile_args = ["-O3", "-std=c++11", "-DHAVE_SCIP"]
 
@@ -21,7 +21,7 @@ if os.name == "nt" and "CONDA_PREFIX" in os.environ:
 # look for various gurobi versions, which are annoyingly
 # suffixed with the version number, and wildcards don't work
 for v in ["100"]:
-    GUROBI_LIB = f"libgurobi{v}" if os.name == 'nt' else f"gurobi{v}"
+    GUROBI_LIB = f"libgurobi{v}" if os.name == "nt" else f"gurobi{v}"
     if (gurolib := util.find_library(GUROBI_LIB)) is not None:
         print("FOUND GUROBI library: ", gurolib)
         libraries.append(GUROBI_LIB)
@@ -31,33 +31,14 @@ else:
     print("WARNING: GUROBI library not found")
 
 
-setup(
-        name='ilpy',
-        version='0.2.2',
-        description='Python wrappers for popular MIP solvers.',
-        url='https://github.com/funkelab/ilpy',
-        author='Jan Funke',
-        author_email='funkej@janelia.hhmi.org',
-        license='MIT',
-        packages=[
-            'ilpy'
-        ],
-        ext_modules=cythonize([
-            Extension(
-                'ilpy.wrapper',
-                sources=[
-                    'ilpy/wrapper.pyx',
-                ],
-                extra_compile_args=compile_args,
-                include_dirs=include_dirs,
-                libraries=libraries,
-                library_dirs=library_dirs,
-                language='c++')
-        ]),
-        extras_require={
-          "dev": ["flake8", "pytest", "pytest-cov"],
-        },
-        package_data={
-            "ilpy": ["py.typed", "*.pyi"]
-        },
+wrapper = Extension(
+    "ilpy.wrapper",
+    sources=["ilpy/wrapper.pyx"],
+    extra_compile_args=compile_args,
+    include_dirs=include_dirs,
+    libraries=libraries,
+    library_dirs=library_dirs,
+    language="c++",
 )
+
+setup(ext_modules=cythonize([wrapper]))


### PR DESCRIPTION
This moves all of the non-cython-related setuptools metadata to pyproject.toml, and sets up dynamic versioning (e.g. the `ilpy.__version__` attribute is now the single source of truth for version info. 

readme updated accordingly