### PR TITLE
Test coverage of cython files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,8 @@ jobs:
         run: |
           python -m pip install -U pip
           python -m pip install -e .[dev]
+        env:
+          CYTHON_TRACE: 1  # enable coverage of cython code
 
       - name: run tests
         run: pytest --color yes -v --cov ilpy --cov-report=xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # ilpy
 
+[![License](https://img.shields.io/pypi/l/ilpy.svg)](https://github.com/funkelab/ilpy/raw/main/LICENSE)
+
+[![Anaconda](https://img.shields.io/conda/v/funkelab/ilpy)](https://anaconda.org/funkelab/ilpy)
+[![PyPI](https://img.shields.io/pypi/v/ilpy.svg)](https://pypi.org/project/ilpy)
+[![CI](https://github.com/funkelab/ilpy/actions/workflows/ci.yaml/badge.svg)](https://github.com/funkelab/ilpy/actions/workflows/ci.yaml)
+[![codecov](https://codecov.io/gh/funkelab/ilpy/branch/main/graph/badge.svg)](https://codecov.io/gh/funkelab/ilpy)
+
 Unified python wrappers for popular ILP solvers
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = []
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
-dev = ["ruff", "mypy", "black", "pytest", "pytest-cov"]
+dev = ["ruff", "mypy", "black", "pytest", "pytest-cov", "cython"]
 
 [project.urls]
 homepage = "https://github.com/funkelab/ilpy"
@@ -47,3 +47,6 @@ files = "ilpy"
 strict = true                 # feel free to relax this if it's annoying
 disallow_any_generics = false
 ignore_missing_imports = true
+
+[tool.coverage.run]
+plugins = ["Cython.Coverage"]

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,9 @@ from Cython.Build import cythonize
 from setuptools import setup
 from setuptools.extension import Extension
 
+# enable test coverage tracing if CYTHON_TRACE is set to a non-zero value
+CYTHON_TRACE = int(os.getenv("CYTHON_TRACE", "0") not in ("0", "False"))
+
 libraries = ["libscip"] if os.name == "nt" else ["scip"]
 include_dirs = ["ilpy/impl"]
 library_dirs = []
@@ -38,6 +41,7 @@ wrapper = Extension(
     libraries=libraries,
     library_dirs=library_dirs,
     language="c++",
+    define_macros=[("CYTHON_TRACE", CYTHON_TRACE)],
 )
 
-setup(ext_modules=cythonize([wrapper]))
+setup(ext_modules=cythonize([wrapper], compiler_directives={"linetrace": CYTHON_TRACE}))


### PR DESCRIPTION
Enable test coverage of cython files.

if you build with `CYTHON_TRACE=1 pip install -e .[dev]`, then `pytest --cov ilpy` will now include coverage for pyx files