### PR TITLE
build: fix build for cython >=3, remove compile-time warnings

### DIFF
--- a/ilpy/impl/solvers/GurobiBackend.cpp
+++ b/ilpy/impl/solvers/GurobiBackend.cpp
@@ -147,12 +147,8 @@ GurobiBackend::setConstraints(const Constraints& constraints) {
 	}
 
 	_numConstraints = constraints.size();
-	unsigned int j = 0;
 	for (const Constraint& constraint : constraints) {
-
 		addConstraint(constraint);
-
-		j++;
 	}
 
 	GRB_CHECK(GRBupdatemodel(_model));

--- a/ilpy/impl/solvers/ScipBackend.cpp
+++ b/ilpy/impl/solvers/ScipBackend.cpp
@@ -3,6 +3,7 @@
 #ifdef HAVE_SCIP
 
 #include <sstream>
+#include <stdexcept> // for std::runtime_error
 
 #include <scip/scipdefplugins.h>
 #include <scip/cons_linear.h>
@@ -131,12 +132,8 @@ ScipBackend::setConstraints(const Constraints& constraints) {
 	// allocate memory for new constraints
 	_constraints.reserve(constraints.size());
 
-	unsigned int j = 0;
 	for (const Constraint& constraint : constraints) {
-
 		addConstraint(constraint);
-
-		j++;
 	}
 }
 
@@ -172,7 +169,7 @@ ScipBackend::addConstraint(const Constraint& constraint) {
 	if (constraint.getRelation() == GreaterEqual)
 		rhs = SCIPinfinity(_scip);
 
-	SCIP_CALL_ABORT(SCIPcreateConsBasicQuadratic(
+	SCIP_CALL_ABORT(SCIPcreateConsBasicQuadraticNonlinear(
 			_scip,
 			&c,
 			name.c_str(),
@@ -323,7 +320,8 @@ ScipBackend::scipVarType(VariableType type, double& lb, double& ub) {
 		return SCIP_VARTYPE_CONTINUOUS;
 	}
 
-	assert(false);
+    // Handle the unexpected value of 'type'
+    throw std::runtime_error("Unhandled VariableType passed to ScipBackend::scipVarType");
 }
 
 #endif // HAVE_SCIP

--- a/ilpy/wrapper.pyx
+++ b/ilpy/wrapper.pyx
@@ -6,7 +6,7 @@ from libcpp.memory cimport shared_ptr
 from libcpp.map cimport map as cppmap
 from libcpp.string cimport string
 from cython.operator cimport dereference as deref
-cimport decl
+from . cimport decl
 from typing import Iterable, Mapping, Sequence
 
 if TYPE_CHECKING:
@@ -47,7 +47,7 @@ cdef class Solution:
 
     def __cinit__(self, size):
         self.p = new decl.Solution(size)
-        self._status = ""
+        self._status = b""
 
     def __dealloc__(self):
         del self.p

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # https://peps.python.org/pep-0517
 [build-system]
-requires = ["setuptools", "Cython<3"]
+requires = ["setuptools", "Cython"]
 build-backend = "setuptools.build_meta"
 
 # https://peps.python.org/pep-0621/

--- a/setup.py
+++ b/setup.py
@@ -44,4 +44,12 @@ wrapper = Extension(
     define_macros=[("CYTHON_TRACE", CYTHON_TRACE)],
 )
 
-setup(ext_modules=cythonize([wrapper], compiler_directives={"linetrace": CYTHON_TRACE}))
+setup(
+    ext_modules=cythonize(
+        [wrapper],
+        compiler_directives={
+            "linetrace": CYTHON_TRACE,
+            "language_level": "3",
+        },
+    )
+)


### PR DESCRIPTION
These fixes allow building to work again with cython 3.0 (it was just using the relative `cimport` and the `b""` string).  I also went through and fixed a few  small compiler warnings