### PR TITLE
feat: ILPY_PREFERENCE env var

### DIFF
--- a/ilpy/wrapper.pyx
+++ b/ilpy/wrapper.pyx
@@ -253,7 +253,9 @@ if env_pref:
             DEFAULT_PREF = p
             break
     else:
-        warnings.warn(f"Unknown ILPY_PREFERENCE {env_pref!r}, using default {DEFAULT_PREF.name}")
+        warnings.warn(
+            f"Unknown ILPY_PREFERENCE {env_pref!r}, using default {DEFAULT_PREF.name}"
+        )
 
 cdef class Solver:
 

--- a/ilpy/wrapper.pyx
+++ b/ilpy/wrapper.pyx
@@ -1,4 +1,7 @@
 # distutils: language = c++
+import os
+import warnings
+
 from typing import TYPE_CHECKING
 
 from libc.stdint cimport uint32_t
@@ -242,6 +245,16 @@ cdef class Constraints:
     def __len__(self):
         return self.p.size()
 
+DEFAULT_PREF = Preference.Any
+env_pref = os.environ.get("ILPY_PREFERENCE")
+if env_pref:
+    for p in Preference:
+        if p.name.lower() == env_pref.lower():
+            DEFAULT_PREF = p
+            break
+    else:
+        warnings.warn(f"Unknown ILPY_PREFERENCE {env_pref!r}, using default {DEFAULT_PREF.name}")
+
 cdef class Solver:
 
     cdef shared_ptr[decl.SolverBackend] p
@@ -252,7 +265,7 @@ cdef class Solver:
             num_variables,
             default_variable_type,
             dict variable_types=None,
-            Preference preference=Preference.Any):
+            Preference preference=DEFAULT_PREF):
         cdef decl.SolverFactory factory
         cdef cppmap[unsigned int, decl.VariableType] vtypes
         if variable_types is not None:


### PR DESCRIPTION
this PR makes it so that you can select the default solver using `ILPY_PREFERENCE=scip` or `ILPY_PREFERENCE=gurobi`.  this makes it easier to quickly swap backends without changing code.  It only changes what happens when a solver is created without an explicit preference, one can still pass `preference=Preference.Any` etc.  If an environment-specified backend is not available, it *will* cause an error unless `Preference.Any` is explicitly passed