### PR TITLE
build: drop python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
           channel-priority: true
 
       - name: install build deps
-        run: mamba install scip gurobi gcovr
+        run: mamba install scip=9.1.0 gurobi gcovr
 
       - name: add gurobi license
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,10 @@ jobs:
             platform: macos-latest
           - python-version: "3.11"
             platform: macos-latest
+          - python-version: "3.13"
+            platform: macos-latest
+          - python-version: "3.13"
+            platform: windows-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,10 +53,6 @@ jobs:
             platform: macos-latest
           - python-version: "3.11"
             platform: macos-latest
-          - python-version: "3.13"
-            platform: macos-latest
-          - python-version: "3.13"
-            platform: windows-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,21 +42,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         platform: [ubuntu-latest, windows-latest]
         include:
           - python-version: "3.9"
             platform: ubuntu-latest
-          - python-version: "3.8"
-            platform: macos-13
           - python-version: "3.9"
             platform: macos-13
           - python-version: "3.10"
             platform: macos-latest
           - python-version: "3.11"
             platform: macos-latest
-          - python-version: "3.12"
-            platform: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -87,7 +83,7 @@ jobs:
           python setup.py build_ext --inplace  # required for C coverage
         env:
           CYTHON_TRACE: 1 # enable coverage of cython code
-          CFLAGS: '-coverage' # enable coverage of C code
+          CFLAGS: "-coverage" # enable coverage of C code
 
       - name: run tests
         run: |
@@ -100,7 +96,7 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml,./coverage_cpp.xml
-        
+
   # we only deploy the sdist to PyPI, the wheel is still complicated
   deploy-sdist:
     if: startsWith(github.ref, 'refs/tags')

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ilpy links against SCIP, so you must have SCIP installed in your environment.
 (You can install via conda)
 
 ```bash
-conda install scip
+conda install scip==9.1.0
 ```
 
 Then clone the repo and install in editable mode.

--- a/ilpy/_functional.py
+++ b/ilpy/_functional.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Callable, Literal, Tuple
+from typing import TYPE_CHECKING, Callable, Literal
 
 from .expressions import Expression
 from .wrapper import (
@@ -15,7 +15,7 @@ from .wrapper import (
 )
 
 if TYPE_CHECKING:
-    ConstraintTuple = Tuple[list[float], Relation | str, float]
+    ConstraintTuple = tuple[list[float], Relation | str, float]
     SenseType = Sense | Literal["minimize", "maximize"]
     VariableTypeType = VariableType | Literal["continuous", "binary", "integer"]
     PreferenceType = Preference | Literal["any", "cplex", "gurobi", "scip"]

--- a/ilpy/_functional.py
+++ b/ilpy/_functional.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable, Iterable, Literal, Mapping, Sequence, Tuple
+from collections.abc import Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Callable, Literal, Tuple
 
 from .expressions import Expression
 from .wrapper import (

--- a/ilpy/expressions.py
+++ b/ilpy/expressions.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import ast
-from typing import Any, ClassVar, Sequence, Union
+from collections.abc import Sequence
+from typing import Any, ClassVar, Union
 
 from ilpy.wrapper import Constraint, Objective, Relation, Sense
 

--- a/ilpy/wrapper.pyi
+++ b/ilpy/wrapper.pyi
@@ -1,5 +1,6 @@
+from collections.abc import Iterable, Mapping, Sequence
 from enum import IntEnum, auto
-from typing import TYPE_CHECKING, Callable, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, Callable
 
 if TYPE_CHECKING:
     LinearCoeffs = Sequence[float] | Mapping[int, float]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # https://peps.python.org/pep-0517
 [build-system]
-requires = ["setuptools==71.0.0", "Cython"]
+requires = ["setuptools==69.5.1", "Cython"]
 build-backend = "setuptools.build_meta"
 
 # https://peps.python.org/pep-0621/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # https://peps.python.org/pep-0517
 [build-system]
-requires = ["setuptools", "Cython"]
+requires = ["setuptools==71.0.0", "Cython"]
 build-backend = "setuptools.build_meta"
 
 # https://peps.python.org/pep-0621/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "cython",
+    "setuptools==69.5.1",
     "numpy",
     "gurobipy",  # used on CI to confirm equality of results
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # https://peps.python.org/pep-0517
 [build-system]
-requires = ["setuptools==69.5.1", "Cython"]
+requires = ["setuptools==71.1.0", "Cython"]
 build-backend = "setuptools.build_meta"
 
 # https://peps.python.org/pep-0621/
@@ -25,7 +25,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "cython",
-    "setuptools==69.5.1",
+    "setuptools==71.1.0",
     "numpy",
     "gurobipy",  # used on CI to confirm equality of results
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "ilpy"
 description = "Python wrappers for popular MIP solvers."
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "MIT" }
 authors = [
     { email = "funkej@janelia.hhmi.org", name = "Jan Funke" },
@@ -48,7 +48,7 @@ readme = { file = ["README.md"] }
 
 # https://beta.ruff.rs/docs
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 src = ["ilpy"]
 
 [tool.ruff.lint]

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import operator
 import os
-from typing import Iterable, NamedTuple, Sequence
+from collections.abc import Iterable, Sequence
+from typing import NamedTuple
 from unittest.mock import Mock
 
 import ilpy


### PR DESCRIPTION
are you ok with dropping python 3.8 @cmalinmayor?  it's the only thing keeping #65 from passing, and python 3.8 is officially end of life