### PR TITLE
Preference.Any uses SCIP if gurobi license is restricted.  Add GurobiRestriced for explicit opt in to the restricted license

### DIFF
--- a/src/ilpy/solver_backends/__init__.py
+++ b/src/ilpy/solver_backends/__init__.py
@@ -55,7 +55,11 @@ def create_solver_backend(preference: Preference | str) -> SolverBackend:
 
 @cache
 def _have_gurobi_license() -> bool:
-    """Check if Gurobi license is available."""
+    """Check if Gurobi license is available.
+
+    This assumes that the license file is located as described in the Gurobi docs:
+    https://support.gurobi.com/hc/en-us/articles/360013417211-Where-do-I-place-the-Gurobi-license-file-gurobi-lic
+    """
     license_file = Path.home() / "gurobi.lic"
     if license_file.exists():
         return True

--- a/src/ilpy/solver_backends/__init__.py
+++ b/src/ilpy/solver_backends/__init__.py
@@ -33,7 +33,7 @@ def create_solver_backend(preference: Preference | str) -> SolverBackend:
     if preference in (Preference.Any, Preference.Scip):
         to_try.append(("_scip", "ScipSolver"))
     if preference in (Preference.Any, Preference.GurobiUnlicensed):
-        to_try.append(("_scip", "ScipSolver"))
+        to_try.append(("_gurobi", "GurobiSolver"))
 
     errors: list[tuple[str, BaseException]] = []
     for modname, clsname in to_try:

--- a/src/ilpy/solver_backends/__init__.py
+++ b/src/ilpy/solver_backends/__init__.py
@@ -10,12 +10,33 @@ __all__ = ["Preference", "SolverBackend", "create_solver_backend"]
 
 
 class Preference(IntEnum):
-    """Preference for a solver backend."""
+    """Preference for a solver backend.
+
+    A "full" Gurobi license means one that is *not* the size-limited license
+    bundled with the `gurobipy` pip wheel. See
+    https://support.gurobi.com/hc/en-us/articles/360051597492
+
+    Attributes
+    ----------
+    Any
+        Use Gurobi if a full license is available, otherwise fall back to SCIP.
+        The bundled size-limited license is treated as "no license" to avoid
+        silent "Model too large" failures on problems with >2000 variables.
+    Scip
+        Use SCIP. Raises if `pyscipopt` is not installed.
+    Gurobi
+        Use Gurobi; requires a full license. Raises otherwise. Use
+        `GurobiRestricted` if you only have the bundled pip license.
+    GurobiRestricted
+        Use Gurobi with whatever license resolves (including the bundled
+        size-limited pip license). Suitable for small problems
+        (<2000 variables); larger ones will fail at solve time.
+    """
 
     Any = auto()
     Scip = auto()
     Gurobi = auto()
-    GurobiUnlicensed = auto()
+    GurobiRestricted = auto()
 
 
 def create_solver_backend(preference: Preference | str) -> SolverBackend:
@@ -31,7 +52,7 @@ def create_solver_backend(preference: Preference | str) -> SolverBackend:
             raise RuntimeError("Gurobi license is not available. ")
     if preference in (Preference.Any, Preference.Scip):
         to_try.append(("_scip", "ScipSolver"))
-    if preference in (Preference.Any, Preference.GurobiUnlicensed):
+    if preference in (Preference.Any, Preference.GurobiRestricted):
         to_try.append(("_gurobi", "GurobiSolver"))
 
     errors: list[tuple[str, BaseException]] = []

--- a/src/ilpy/solver_backends/__init__.py
+++ b/src/ilpy/solver_backends/__init__.py
@@ -16,21 +16,15 @@ class Preference(IntEnum):
     bundled with the `gurobipy` pip wheel. See
     https://support.gurobi.com/hc/en-us/articles/360051597492
 
-    Attributes
-    ----------
-    Any
-        Use Gurobi if a full license is available, otherwise fall back to SCIP.
-        The bundled size-limited license is treated as "no license" to avoid
-        silent "Model too large" failures on problems with >2000 variables.
-    Scip
-        Use SCIP. Raises if `pyscipopt` is not installed.
-    Gurobi
-        Use Gurobi; requires a full license. Raises otherwise. Use
-        `GurobiRestricted` if you only have the bundled pip license.
-    GurobiRestricted
-        Use Gurobi with whatever license resolves (including the bundled
-        size-limited pip license). Suitable for small problems
-        (<2000 variables); larger ones will fail at solve time.
+    - `Any`: Use Gurobi if a full license is available, otherwise fall back
+      to SCIP. The bundled size-limited license is treated as "no license" to
+      avoid silent "Model too large" failures on problems with >2000 variables.
+    - `Scip`: Use SCIP. Raises if `pyscipopt` is not installed.
+    - `Gurobi`: Use Gurobi; requires a full license. Raises otherwise. Use
+      `GurobiRestricted` if you only have the bundled pip license.
+    - `GurobiRestricted`: Use Gurobi with whatever license resolves
+      (including the bundled size-limited pip license). Suitable for small
+      problems (<2000 variables); larger ones will fail at solve time.
     """
 
     Any = auto()

--- a/src/ilpy/solver_backends/__init__.py
+++ b/src/ilpy/solver_backends/__init__.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import os
+from contextlib import suppress
 from enum import IntEnum, auto
 from functools import cache
-from pathlib import Path
 
 from ._base import SolverBackend
 
@@ -55,14 +54,29 @@ def create_solver_backend(preference: Preference | str) -> SolverBackend:
 
 @cache
 def _have_gurobi_license() -> bool:
-    """Check if Gurobi license is available.
+    """Return True if a real (non size-limited) Gurobi license is available.
 
-    This assumes that the license file is located as described in the Gurobi docs:
-    https://support.gurobi.com/hc/en-us/articles/360013417211-Where-do-I-place-the-Gurobi-license-file-gurobi-lic
+    Delegates license resolution to gurobipy itself so every documented search
+    location is honored — the `GRB_LICENSE_FILE` environment variable, the
+    user's home directory, and the platform-specific shared install directory
+    (`/opt/gurobi` on Linux, `/Library/gurobi` on macOS, `C:\\gurobi` on
+    Windows). See
+    https://support.gurobi.com/hc/en-us/articles/360013417211
+
+    The pip/conda `gurobipy` wheel ships with a bundled size-limited license
+    (max 2000 variables); it reports `LicenseID == 0`. We treat that case as
+    "no license" so callers can fall back to SCIP for larger problems.
     """
-    license_file = Path.home() / "gurobi.lic"
-    if license_file.exists():
-        return True
-    if (env_file := os.getenv("GRB_LICENSE_FILE", "")) and Path(env_file).exists():
-        return True
+    try:
+        import gurobipy as gp
+    except ImportError:
+        return False
+    with suppress(Exception):
+        # empty=True defers license validation until start()
+        with gp.Env(empty=True) as env:
+            # silence the startup banner and the "Restricted license" notice
+            env.setParam("OutputFlag", 0)
+            env.start()
+            return int(env.getParam("LicenseID")) != 0
+    # no license file found, or license expired
     return False

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -34,6 +34,7 @@ except Exception as e:
 PREFS = [
     pytest.param(ilpy.Preference.Scip, id="scip"),
     pytest.param(ilpy.Preference.Gurobi, marks=gu_marks, id="gurobi"),
+    pytest.param(ilpy.Preference.GurobiUnlicensed, id="gurobi-restricted"),
 ]
 
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -16,12 +16,14 @@ if TYPE_CHECKING:
 
     from ilpy._constants import VariableType
 
-# XFAIL if no gurobi not installed or no license found
-# (this is the best way I could find to determine this so far)
+# XFAIL gurobi tests if the requested license mode is unavailable:
+# - `gurobi` needs a full license
+# - `gurobi-restricted` needs at least the bundled/size-limited pip license
+#   (which is poisoned if GRB_LICENSE_FILE is set but points to a stale file)
+from ilpy.solver_backends import create_solver_backend
+
 gu_marks = []
 try:
-    from ilpy.solver_backends import create_solver_backend
-
     create_solver_backend(ilpy.Preference.Gurobi)
     import gurobipy as gb
 
@@ -31,10 +33,18 @@ except Exception as e:
     gb = None
     HAVE_GUROBI = False
 
+gr_marks = []
+try:
+    create_solver_backend(ilpy.Preference.GurobiUnlicensed)
+except Exception as e:
+    gr_marks.append(pytest.mark.xfail(reason=f"Gurobi restricted error: {e}"))
+
 PREFS = [
     pytest.param(ilpy.Preference.Scip, id="scip"),
     pytest.param(ilpy.Preference.Gurobi, marks=gu_marks, id="gurobi"),
-    pytest.param(ilpy.Preference.GurobiUnlicensed, id="gurobi-restricted"),
+    pytest.param(
+        ilpy.Preference.GurobiUnlicensed, marks=gr_marks, id="gurobi-restricted"
+    ),
 ]
 
 

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -35,7 +35,7 @@ except Exception as e:
 
 gr_marks = []
 try:
-    create_solver_backend(ilpy.Preference.GurobiUnlicensed)
+    create_solver_backend(ilpy.Preference.GurobiRestricted)
 except Exception as e:
     gr_marks.append(pytest.mark.xfail(reason=f"Gurobi restricted error: {e}"))
 
@@ -43,7 +43,7 @@ PREFS = [
     pytest.param(ilpy.Preference.Scip, id="scip"),
     pytest.param(ilpy.Preference.Gurobi, marks=gu_marks, id="gurobi"),
     pytest.param(
-        ilpy.Preference.GurobiUnlicensed, marks=gr_marks, id="gurobi-restricted"
+        ilpy.Preference.GurobiRestricted, marks=gr_marks, id="gurobi-restricted"
     ),
 ]
 


### PR DESCRIPTION
fixes #74 

cc @cmalinmayor  

| gurobipy | License state | `_have_gurobi_license()` | `Any` | `Scip` | `Gurobi` | `GurobiRestriced` |         
  |:--:|---|:--:|---|---|---|---|                   
  | ✓ | real valid license | **True** | Gurobi | Scip | Gurobi | Gurobi |                                          
 | ✓ | `GRB_LICENSE_FILE=/nonexistent` | False | **Scip** | Scip | raises | raises |                              
| ✓ | `GRB_LICENSE_FILE=/malformed` (stale CI) | False | **Scip** | Scip | raises | raises |                     
| ✗ | n/a | False | **Scip** | Scip | raises | raises |                                                          
| ✓ | bundled pip license only | False | **Scip ✓#74** | Scip | raises | Gurobi (size-limited) | 