### PR TITLE
refactor: optimize coefficient extraction to avoid recursion limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.xml
 coverage_cpp.xml
 docs/_build/
 docs/build/
+uv.lock


### PR DESCRIPTION
another attempt to fix #64 

this uses an explicit stack rather than recursion