### PR TITLE
Include objective constant in Gurobi solution value

### DIFF
--- a/src/ilpy/solver_backends/_gurobi.py
+++ b/src/ilpy/solver_backends/_gurobi.py
@@ -84,6 +84,7 @@ class GurobiSolver(SolverBackend):
         )
         for (i, j), qcoef in objective.get_quadratic_coefficients().items():
             obj += qcoef * self._vars[i] * self._vars[j]
+        obj += objective.get_constant()
         sense = SENSE_MAP[objective.get_sense()]
         self._model.setObjective(obj, sense)
 


### PR DESCRIPTION
_Problem_

The Gurobi backend's `set_objective` did not pass the objective constant to Gurobi, so `solution.get_value()` returned only the variable-dependent part of the objective. The [SCIP backend](https://github.com/funkelab/ilpy/blob/main/src/ilpy/solver_backends/_scip.py) correctly included the constant, making the two backends inconsistent.

_Fix_

Add `obj += objective.get_constant()` in `GurobiSolver.set_objective` before calling `model.setObjective`. Gurobi propagates the constant into `ObjVal`, so `solution.get_value()` now returns the full objective value on both backends.