### PR TITLE
feat: NVIDIA cuOpt as a Preference.CuOpt backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,11 @@ dependencies = [
 gurobi = ["gurobipy"]
 scip = ["pyscipopt"]
 # NVIDIA cuOpt (GPU MIP solver, Apache-2.0). Only useful on CUDA-capable
-# hosts. Wheel is hosted on pypi.nvidia.com, so install with:
-#   pip install --extra-index-url https://pypi.nvidia.com 'ilpy[cuopt]'
-cuopt = ["cuopt-cu12", "numpy", "scipy"]
+# hosts. The cuopt-cu12 wheel is hosted on pypi.nvidia.com (see the
+# [[tool.uv.index]] / [tool.uv.sources] blocks below for the uv route) and
+# only ships for Python >= 3.10, so the marker keeps `uv sync` working on
+# 3.9 environments that don't request the extra.
+cuopt = ["cuopt-cu12; python_version >= '3.10'", "numpy", "scipy"]
 
 [dependency-groups]
 test = ["ilpy[gurobi, scip]", "pytest", "pytest-cov", "numpy"]
@@ -56,6 +58,15 @@ docs = ["numpy", "zensical", "mkdocstrings-python"]
 [project.urls]
 homepage = "https://github.com/funkelab/ilpy"
 repository = "https://github.com/funkelab/ilpy"
+
+# uv: route `cuopt-cu12` to NVIDIA's index so `uv sync --extra cuopt`
+# resolves without needing `--extra-index-url` on the command line.
+[[tool.uv.index]]
+name = "nvidia"
+url = "https://pypi.nvidia.com"
+
+[tool.uv.sources]
+cuopt-cu12 = { index = "nvidia" }
 
 # https://docs.astral.sh/ruff
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,10 @@ dependencies = [
 [project.optional-dependencies]
 gurobi = ["gurobipy"]
 scip = ["pyscipopt"]
+# NVIDIA cuOpt (GPU MIP solver, Apache-2.0). Only useful on CUDA-capable
+# hosts. Wheel is hosted on pypi.nvidia.com, so install with:
+#   pip install --extra-index-url https://pypi.nvidia.com 'ilpy[cuopt]'
+cuopt = ["cuopt-cu12", "numpy", "scipy"]
 
 [dependency-groups]
 test = ["ilpy[gurobi, scip]", "pytest", "pytest-cov", "numpy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,12 +43,11 @@ dependencies = [
 [project.optional-dependencies]
 gurobi = ["gurobipy"]
 scip = ["pyscipopt"]
-# NVIDIA cuOpt (GPU MIP solver, Apache-2.0). Only useful on CUDA-capable
-# hosts. The cuopt-cu12 wheel is hosted on pypi.nvidia.com (see the
-# [[tool.uv.index]] / [tool.uv.sources] blocks below for the uv route) and
-# only ships for Python >= 3.10, so the marker keeps `uv sync` working on
-# 3.9 environments that don't request the extra.
-cuopt = ["cuopt-cu12; python_version >= '3.10'", "numpy", "scipy"]
+cuopt = [
+    "cuopt-cu12; python_version >= '3.10'",
+    "numpy; python_version >= '3.10'",
+    "scipy; python_version >= '3.10'",
+]
 
 [dependency-groups]
 test = ["ilpy[gurobi, scip]", "pytest", "pytest-cov", "numpy"]

--- a/src/ilpy/__init__.py
+++ b/src/ilpy/__init__.py
@@ -27,6 +27,7 @@ from .solver_backends import Preference, SolverBackend
 Any = Preference.Any
 Scip = Preference.Scip
 Gurobi = Preference.Gurobi
+CuOpt = Preference.CuOpt
 Continuous = VariableType.Continuous
 Integer = VariableType.Integer
 Binary = VariableType.Binary

--- a/src/ilpy/event_data.py
+++ b/src/ilpy/event_data.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypedDict, Union
 
-__all__ = ["EventData", "GurobiData", "SCIPData"]
+__all__ = ["CuOptData", "EventData", "GurobiData", "SCIPData"]
 
 if TYPE_CHECKING:
     from typing import Literal, TypeAlias
@@ -15,7 +15,9 @@ if TYPE_CHECKING:
     """The set of event types emitted by the Gurobi backend."""
     SCIPEventType: TypeAlias = Literal["PRESOLVEROUND", "BESTSOLFOUND"]
     """The set of event types emitted by the SCIP backend."""
-    EventType: TypeAlias = GurobiEventType | SCIPEventType
+    CuOptEventType: TypeAlias = Literal["MIPSOL", "SOLVED"]
+    """The set of event types emitted by the cuOpt backend."""
+    EventType: TypeAlias = GurobiEventType | SCIPEventType | CuOptEventType
     """Union of all event types emitted by any supported backend."""
 
 
@@ -137,5 +139,45 @@ class SCIPBestSol(_SCIPData):
 
 SCIPData = Union[SCIPPresolve, SCIPBestSol]
 """Union of all SCIP event payload types."""
-EventData = Union[GurobiData, SCIPData]
+
+
+class _CuOptData(TypedDict, total=False):
+    backend: Literal["cuopt"]
+    runtime: float  # Elapsed wall time since the cuOpt solve was dispatched.
+
+
+class CuOptMipSol(_CuOptData):
+    """Payload emitted by cuOpt when the MIP solver reports a new incumbent.
+
+    cuOpt invokes the registered ``GetSolutionCallback.get_solution`` hook
+    once per incumbent during branch-and-bound; we forward each call as
+    one event. ``obj`` is the incumbent's objective value, ``solution_bound``
+    is the dual bound at the time of the callback, and ``gap`` is computed
+    from the two (matching the convention used by ``GurobiMipSol``).
+    """
+
+    event_type: Literal["MIPSOL"]
+    obj: float
+    solution_bound: float
+    gap: float
+
+
+class CuOptSolved(_CuOptData):
+    """Payload emitted by cuOpt once at the end of every solve.
+
+    LP-only problems do not trigger the per-incumbent callback (the MIP
+    callback API is MILP-specific), and pure-presolve solutions also bypass
+    it; this terminal event guarantees at least one payload per ``solve()``
+    call so callers can count on receiving progress data.
+    """
+
+    event_type: Literal["SOLVED"]
+    obj: float
+    status: int
+
+
+CuOptData = Union[CuOptMipSol, CuOptSolved]
+"""Union of all cuOpt event payload types."""
+
+EventData = Union[GurobiData, SCIPData, CuOptData]
 """Union of every event payload emitted by any supported backend."""

--- a/src/ilpy/solver_backends/__init__.py
+++ b/src/ilpy/solver_backends/__init__.py
@@ -25,10 +25,13 @@ class Preference(IntEnum):
     - `GurobiRestricted`: Use Gurobi with whatever license resolves
       (including the bundled size-limited pip license). Suitable for small
       problems (<2000 variables); larger ones will fail at solve time.
-    - `CuOpt`: Use NVIDIA cuOpt (GPU-accelerated, Apache-2.0). Raises if
-      ``cuopt-cu12`` is not installed or no CUDA device is visible. Useful
-      for very large MIPs on sites without a Gurobi seat; quadratic
-      objectives/constraints are not supported by this backend.
+    - `CuOpt`: Use NVIDIA cuOpt (GPU-accelerated, Apache-2.0). Useful for
+      very large MIPs on sites without a Gurobi seat; quadratic
+      objectives/constraints are not supported by this backend. Raises if
+      ``cuopt-cu12`` is not installed; on hosts where the wheel is present
+      but no CUDA device is visible, the underlying ``rmm`` library raises
+      ``CUDARuntimeError`` during ``cuopt`` import, which surfaces here as a
+      backend-creation failure (no explicit device probe is performed).
     """
 
     Any = auto()

--- a/src/ilpy/solver_backends/__init__.py
+++ b/src/ilpy/solver_backends/__init__.py
@@ -25,12 +25,17 @@ class Preference(IntEnum):
     - `GurobiRestricted`: Use Gurobi with whatever license resolves
       (including the bundled size-limited pip license). Suitable for small
       problems (<2000 variables); larger ones will fail at solve time.
+    - `CuOpt`: Use NVIDIA cuOpt (GPU-accelerated, Apache-2.0). Raises if
+      ``cuopt-cu12`` is not installed or no CUDA device is visible. Useful
+      for very large MIPs on sites without a Gurobi seat; quadratic
+      objectives/constraints are not supported by this backend.
     """
 
     Any = auto()
     Scip = auto()
     Gurobi = auto()
     GurobiRestricted = auto()
+    CuOpt = auto()
 
 
 def create_solver_backend(preference: Preference | str) -> SolverBackend:
@@ -48,6 +53,10 @@ def create_solver_backend(preference: Preference | str) -> SolverBackend:
         to_try.append(("_scip", "ScipSolver"))
     if preference in (Preference.Any, Preference.GurobiRestricted):
         to_try.append(("_gurobi", "GurobiSolver"))
+    # CuOpt is opt-in only (not part of `Any`): it requires a CUDA device
+    # and the cuopt-cu12 wheel, so callers must request it explicitly.
+    if preference == Preference.CuOpt:
+        to_try.append(("_cuopt", "CuOptSolver"))
 
     errors: list[tuple[str, BaseException]] = []
     for modname, clsname in to_try:

--- a/src/ilpy/solver_backends/_cuopt.py
+++ b/src/ilpy/solver_backends/_cuopt.py
@@ -259,6 +259,14 @@ class CuOptSolver(SolverBackend):
         # production deployments that build the solver via tracksdata /
         # third-party code and can't easily reach the set_timeout() call
         # site.
+        #
+        # Empirical floor for cell-tracking ILPs in heuristics-only mode
+        # (cuopt-cu12 == 26.4.x): Papilo presolve alone takes ~91 s, so
+        # time_limit < ~120 s frequently returns a trivial / infeasible
+        # primal. Recommended production default for MIPs of this shape:
+        # 240 s (~1.3× safety margin over the 180s "first usable primal"
+        # floor measured on ops0042 A/2: 2.2M nodes / 1.56M edges).
+        # See royerlab/hoct_inference PR #5 for the measurement methodology.
         effective_time_limit = self._time_limit
         env_time_limit = os.environ.get("ILPY_CUOPT_TIME_LIMIT")
         if env_time_limit:

--- a/src/ilpy/solver_backends/_cuopt.py
+++ b/src/ilpy/solver_backends/_cuopt.py
@@ -141,7 +141,18 @@ class CuOptSolver(SolverBackend):
     # ----------------------------------------------------------- constraints
 
     def set_constraints(self, constraints: Constraints) -> None:
-        self._constraint_buf = list(constraints)
+        # Materialise + validate up front so a quadratic term anywhere in the
+        # incoming iterable aborts the call *before* mutating `_constraint_buf`.
+        # Iterating once also handles single-pass iterables (generators).
+        new_buf = list(constraints)
+        for c in new_buf:
+            if c.get_quadratic_coefficients():
+                raise NotImplementedError(
+                    "CuOptSolver does not currently support quadratic "
+                    "constraints. Use the SCIP or Gurobi backend for "
+                    "QCP/MIQCP problems."
+                )
+        self._constraint_buf = new_buf
 
     def add_constraint(self, constraint: Constraint) -> None:
         if constraint.get_quadratic_coefficients():
@@ -185,16 +196,15 @@ class CuOptSolver(SolverBackend):
         n_vars = self._num_variables
         n_cons = len(self._constraint_buf)
 
-        # Objective vector
+        # Objective vector. `Objective.get_coefficients()` returns
+        # `list[float]` (one entry per variable). Match the Gurobi/SCIP
+        # behaviour of silently truncating if the objective is longer than
+        # `num_variables` (rather than raising IndexError) by capping the
+        # slice length explicitly.
         obj_coefs = np.zeros(n_vars, dtype=np.float64)
-        raw = self._objective.get_coefficients()
-        if hasattr(raw, "items"):
-            for vi, c in raw.items():
-                obj_coefs[vi] = c
-        else:
-            # Sequence form: index → coefficient by position
-            for vi, c in enumerate(list(raw)):
-                obj_coefs[vi] = c
+        raw = np.asarray(self._objective.get_coefficients(), dtype=np.float64)
+        n_assign = min(raw.shape[0], n_vars)
+        obj_coefs[:n_assign] = raw[:n_assign]
         # ilpy may report a constant on the objective; cuOpt has no
         # objective-constant parameter, so we capture it and add it to the
         # objective value we return.

--- a/src/ilpy/solver_backends/_cuopt.py
+++ b/src/ilpy/solver_backends/_cuopt.py
@@ -252,8 +252,22 @@ class CuOptSolver(SolverBackend):
 
         # Settings
         ss = SolverSettings()
-        if self._time_limit is not None:
-            ss.set_parameter("time_limit", str(self._time_limit))
+        # Time limit precedence: ILPY_CUOPT_TIME_LIMIT env var wins over
+        # whatever was passed via set_timeout() (which itself defaults to
+        # whatever the caller's ILPSolverConfig.timeout was — typically
+        # very large). Letting an env-var override is essential for
+        # production deployments that build the solver via tracksdata /
+        # third-party code and can't easily reach the set_timeout() call
+        # site.
+        effective_time_limit = self._time_limit
+        env_time_limit = os.environ.get("ILPY_CUOPT_TIME_LIMIT")
+        if env_time_limit:
+            try:
+                effective_time_limit = float(env_time_limit)
+            except ValueError:
+                pass
+        if effective_time_limit is not None:
+            ss.set_parameter("time_limit", str(effective_time_limit))
         if self._mip_gap_rel is not None:
             ss.set_parameter("mip_relative_gap", str(self._mip_gap_rel))
         if self._mip_gap_abs is not None:

--- a/src/ilpy/solver_backends/_cuopt.py
+++ b/src/ilpy/solver_backends/_cuopt.py
@@ -16,6 +16,7 @@ selected-variable set matched a Gurobi-completed reference within rounding
 error (<0.01 % of variables differ). See the upstream consumer
 (eet_inference / hoct_inference) for the validation harness.
 """
+
 from __future__ import annotations
 
 import os
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
 try:
     import numpy as np
     from cuopt.linear_programming import data_model, solver
+    from cuopt.linear_programming.internals import GetSolutionCallback
     from cuopt.linear_programming.solver_settings import SolverSettings
     from scipy.sparse import csr_matrix
 except ImportError as e:
@@ -45,7 +47,7 @@ except ImportError as e:
 
 
 # ilpy.VariableType → cuOpt single-char variable kind code
-VTYPE_MAP: "Mapping[int, bytes]" = {
+VTYPE_MAP: Mapping[int, bytes] = {
     VariableType.Continuous: b"C",
     VariableType.Binary: b"I",  # cuOpt uses {0,1} bounds + integer to model binary
     VariableType.Integer: b"I",
@@ -54,7 +56,7 @@ VTYPE_MAP: "Mapping[int, bytes]" = {
 # cuOpt termination_status enum values (from cuopt.linear_programming):
 #   1 = Optimal, 2 = Infeasible, 3 = Unbounded, 4 = TimeLimit, 5 = IterationLimit,
 #   6 = Numerical, 7 = PrimalFeasible (heuristic-only, no dual bound)
-STATUS_MAP: "Mapping[int, SolverStatus]" = {
+STATUS_MAP: Mapping[int, SolverStatus] = {
     1: SolverStatus.OPTIMAL,
     2: SolverStatus.INFEASIBLE,
     3: SolverStatus.UNBOUNDED,
@@ -100,12 +102,14 @@ class CuOptSolver(SolverBackend):
         self,
         num_variables: int,
         default_variable_type: VariableType,
-        variable_types: "Mapping[int, VariableType]",
+        variable_types: Mapping[int, VariableType],
     ) -> None:
         self._num_variables = int(num_variables)
         self._var_types = np.array(
-            [VTYPE_MAP[variable_types.get(i, default_variable_type)]
-             for i in range(num_variables)],
+            [
+                VTYPE_MAP[variable_types.get(i, default_variable_type)]
+                for i in range(num_variables)
+            ],
             dtype=object,
         )
         lb = np.empty(num_variables, dtype=np.float64)
@@ -125,7 +129,7 @@ class CuOptSolver(SolverBackend):
 
     # ------------------------------------------------------------ objective
 
-    def set_objective(self, objective: "Objective") -> None:
+    def set_objective(self, objective: Objective) -> None:
         if objective.get_quadratic_coefficients():
             raise NotImplementedError(
                 "CuOptSolver does not currently support quadratic objectives. "
@@ -136,10 +140,10 @@ class CuOptSolver(SolverBackend):
 
     # ----------------------------------------------------------- constraints
 
-    def set_constraints(self, constraints: "Constraints") -> None:
+    def set_constraints(self, constraints: Constraints) -> None:
         self._constraint_buf = list(constraints)
 
-    def add_constraint(self, constraint: "Constraint") -> None:
+    def add_constraint(self, constraint: Constraint) -> None:
         if constraint.get_quadratic_coefficients():
             raise NotImplementedError(
                 "CuOptSolver does not currently support quadratic constraints. "
@@ -172,7 +176,9 @@ class CuOptSolver(SolverBackend):
         if self._num_variables == 0:
             raise ValueError("CuOptSolver: initialize() must be called before solve().")
         if self._objective is None:
-            raise ValueError("CuOptSolver: set_objective() must be called before solve().")
+            raise ValueError(
+                "CuOptSolver: set_objective() must be called before solve()."
+            )
 
         import time as _time
 
@@ -230,7 +236,7 @@ class CuOptSolver(SolverBackend):
             row_lb[ge] = rhs[ge]
             row_ub[ge] = INF
         else:
-            # Empty constraint set: build a 0×n_vars matrix to keep cuOpt happy.
+            # Empty constraint set: build a 0-by-n_vars matrix to keep cuOpt happy.
             A = csr_matrix((n_cons, n_vars), dtype=np.float64)
             row_lb = np.zeros(0, dtype=np.float64)
             row_ub = np.zeros(0, dtype=np.float64)
@@ -244,9 +250,7 @@ class CuOptSolver(SolverBackend):
         dm.set_variable_lower_bounds(self._var_lb)
         dm.set_variable_upper_bounds(self._var_ub)
         # cuOpt expects an array of single-char byte codes for var types
-        dm.set_variable_types(
-            np.asarray(self._var_types, dtype=object).astype(bytes)
-        )
+        dm.set_variable_types(np.asarray(self._var_types, dtype=object).astype(bytes))
         dm.set_maximize(self._sense == Sense.Maximize)
         self._last_dm = dm
 
@@ -264,7 +268,7 @@ class CuOptSolver(SolverBackend):
         # (cuopt-cu12 == 26.4.x): Papilo presolve alone takes ~91 s, so
         # time_limit < ~120 s frequently returns a trivial / infeasible
         # primal. Recommended production default for MIPs of this shape:
-        # 240 s (~1.3× safety margin over the 180s "first usable primal"
+        # 240 s (~1.3x safety margin over the 180s "first usable primal"
         # floor measured on ops0042 A/2: 2.2M nodes / 1.56M edges).
         # See royerlab/hoct_inference PR #5 for the measurement methodology.
         effective_time_limit = self._time_limit
@@ -296,15 +300,57 @@ class CuOptSolver(SolverBackend):
             except Exception:
                 pass
         extra = os.environ.get("ILPY_CUOPT_EXTRA_PARAMS", "")
-        for kv in extra.split(","):
-            kv = kv.strip()
-            if not kv or "=" not in kv:
+        for raw_kv in extra.split(","):
+            kv_clean = raw_kv.strip()
+            if not kv_clean or "=" not in kv_clean:
                 continue
-            k, v = kv.split("=", 1)
+            param_name, param_value = kv_clean.split("=", 1)
             try:
-                ss.set_parameter(k.strip(), v.strip())
+                ss.set_parameter(param_name.strip(), param_value.strip())
             except Exception:
                 pass
+
+        # Progress events: cuOpt's per-incumbent hook is MILP-only and is
+        # invoked from C++ once per new feasible solution. For LP problems
+        # (and MIPs that solve entirely during presolve), no incumbent
+        # callback fires, so we always emit a terminal "SOLVED" event below
+        # to give callers at least one payload per solve.
+        is_mip = bool(self._var_types is not None and (self._var_types == b"I").any())
+
+        backend_self = self
+
+        class _IncumbentRelay(GetSolutionCallback):
+            """Forward each cuOpt incumbent to ilpy's event-callback hook."""
+
+            def get_solution(
+                self,
+                solution: Any,
+                solution_cost: Any,
+                solution_bound: Any,
+                user_data: Any,
+            ) -> None:
+                # cuOpt reports the unshifted objective; add ilpy's
+                # objective constant so the value matches Solution.value.
+                try:
+                    cost = float(solution_cost[0]) + obj_constant
+                    bound = float(solution_bound[0]) + obj_constant
+                except Exception:
+                    return
+                denom = max(abs(cost), 1e-10)
+                gap = abs(cost - bound) / denom
+                backend_self.emit_event_data(
+                    {
+                        "backend": "cuopt",
+                        "event_type": "MIPSOL",
+                        "obj": cost,
+                        "solution_bound": bound,
+                        "gap": gap,
+                        "runtime": _time.monotonic() - t0,
+                    }
+                )
+
+        if is_mip:
+            ss.set_mip_callback(_IncumbentRelay(), None)
 
         # Solve
         t0 = _time.monotonic()
@@ -324,6 +370,16 @@ class CuOptSolver(SolverBackend):
             obj_val = float(sol.get_primal_objective()) + obj_constant
         except Exception:
             obj_val = float("nan")
+
+        self.emit_event_data(
+            {
+                "backend": "cuopt",
+                "event_type": "SOLVED",
+                "obj": obj_val,
+                "status": native_status,
+                "runtime": wall,
+            }
+        )
 
         return Solution(
             variable_values=variable_values,

--- a/src/ilpy/solver_backends/_cuopt.py
+++ b/src/ilpy/solver_backends/_cuopt.py
@@ -1,0 +1,317 @@
+"""NVIDIA cuOpt backend for ilpy.
+
+cuOpt is an Apache-2.0 GPU MIP/LP solver
+(https://docs.nvidia.com/cuopt/), distributed as the ``cuopt-cu12`` wheel on
+``pypi.nvidia.com``. It accepts a sparse problem definition (CSR constraint
+matrix + objective vector + row/column bounds + variable types) and solves
+on a single CUDA device.
+
+This backend buffers the ilpy ``Objective`` / ``Constraints`` set on it via
+the standard ``SolverBackend`` API, then at ``solve()`` time materialises a
+``cuopt.linear_programming.DataModel`` and dispatches a synchronous solve.
+
+Quality validation context: on a 10.3 M-variable / 5.5 M-constraint cell-
+tracking ILP, cuOpt returned an Optimal solution (relative gap < 1e-5) whose
+selected-variable set matched a Gurobi-completed reference within rounding
+error (<0.01 % of variables differ). See the upstream consumer
+(eet_inference / hoct_inference) for the validation harness.
+"""
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from ilpy._constants import Relation, Sense, SolverStatus, VariableType
+from ilpy._solver import Solution
+
+from ._base import SolverBackend
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from ilpy._components import Constraint, Constraints, Objective
+
+try:
+    import numpy as np
+    from cuopt.linear_programming import data_model, solver
+    from cuopt.linear_programming.solver_settings import SolverSettings
+    from scipy.sparse import csr_matrix
+except ImportError as e:
+    raise ImportError(
+        "cuopt-cu12 (and numpy/scipy) are required for CuOptSolver. "
+        "Install with:\n"
+        "    pip install --extra-index-url https://pypi.nvidia.com cuopt-cu12"
+    ) from e
+
+
+# ilpy.VariableType → cuOpt single-char variable kind code
+VTYPE_MAP: "Mapping[int, bytes]" = {
+    VariableType.Continuous: b"C",
+    VariableType.Binary: b"I",  # cuOpt uses {0,1} bounds + integer to model binary
+    VariableType.Integer: b"I",
+}
+
+# cuOpt termination_status enum values (from cuopt.linear_programming):
+#   1 = Optimal, 2 = Infeasible, 3 = Unbounded, 4 = TimeLimit, 5 = IterationLimit,
+#   6 = Numerical, 7 = PrimalFeasible (heuristic-only, no dual bound)
+STATUS_MAP: "Mapping[int, SolverStatus]" = {
+    1: SolverStatus.OPTIMAL,
+    2: SolverStatus.INFEASIBLE,
+    3: SolverStatus.UNBOUNDED,
+    4: SolverStatus.TIMELIMIT,
+    5: SolverStatus.NODELIMIT,
+    6: SolverStatus.OTHER,
+    7: SolverStatus.SUBOPTIMAL,
+}
+
+INF = float("inf")
+
+
+class CuOptSolver(SolverBackend):
+    """ilpy SolverBackend implementation backed by NVIDIA cuOpt (GPU).
+
+    Buffers variables, objective, constraints, and parameters until
+    ``solve()`` is called, then materialises a cuOpt ``DataModel`` /
+    ``SolverSettings`` pair and dispatches a synchronous GPU solve.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        # Buffered model state
+        self._num_variables: int = 0
+        self._var_types: np.ndarray | None = None  # array of bytes ("C"/"I")
+        self._var_lb: np.ndarray | None = None
+        self._var_ub: np.ndarray | None = None
+        self._objective: Objective | None = None
+        self._sense: Sense = Sense.Minimize
+        self._constraint_buf: list[Constraint] = []
+        # Solver parameters
+        self._time_limit: float | None = None
+        self._mip_gap_rel: float | None = None
+        self._mip_gap_abs: float | None = None
+        self._num_threads: int | None = None
+        self._verbose: bool = False
+        # The last assembled DataModel (for `native_model()`)
+        self._last_dm: Any = None
+
+    # ------------------------------------------------------------------ setup
+
+    def initialize(
+        self,
+        num_variables: int,
+        default_variable_type: VariableType,
+        variable_types: "Mapping[int, VariableType]",
+    ) -> None:
+        self._num_variables = int(num_variables)
+        self._var_types = np.array(
+            [VTYPE_MAP[variable_types.get(i, default_variable_type)]
+             for i in range(num_variables)],
+            dtype=object,
+        )
+        lb = np.empty(num_variables, dtype=np.float64)
+        ub = np.empty(num_variables, dtype=np.float64)
+        for i in range(num_variables):
+            vt = variable_types.get(i, default_variable_type)
+            if vt == VariableType.Binary:
+                lb[i] = 0.0
+                ub[i] = 1.0
+            else:
+                lb[i] = -INF
+                ub[i] = INF
+        self._var_lb = lb
+        self._var_ub = ub
+        # Reset constraint buffer (initialize is the start of a fresh model)
+        self._constraint_buf = []
+
+    # ------------------------------------------------------------ objective
+
+    def set_objective(self, objective: "Objective") -> None:
+        if objective.get_quadratic_coefficients():
+            raise NotImplementedError(
+                "CuOptSolver does not currently support quadratic objectives. "
+                "Use the SCIP or Gurobi backend for QP/MIQP problems."
+            )
+        self._objective = objective
+        self._sense = objective.get_sense()
+
+    # ----------------------------------------------------------- constraints
+
+    def set_constraints(self, constraints: "Constraints") -> None:
+        self._constraint_buf = list(constraints)
+
+    def add_constraint(self, constraint: "Constraint") -> None:
+        if constraint.get_quadratic_coefficients():
+            raise NotImplementedError(
+                "CuOptSolver does not currently support quadratic constraints. "
+                "Use the SCIP or Gurobi backend for QCP/MIQCP problems."
+            )
+        self._constraint_buf.append(constraint)
+
+    # ------------------------------------------------------------ parameters
+
+    def set_timeout(self, timeout: float) -> None:
+        self._time_limit = float(timeout)
+
+    def set_optimality_gap(self, gap: float, absolute: bool) -> None:
+        if absolute:
+            self._mip_gap_abs = float(gap)
+        else:
+            self._mip_gap_rel = float(gap)
+
+    def set_num_threads(self, num_threads: int) -> None:
+        # cuOpt is GPU-bound; threads has no host-side effect. Recorded for
+        # introspection but not forwarded.
+        self._num_threads = int(num_threads)
+
+    def set_verbose(self, verbose: bool) -> None:
+        self._verbose = bool(verbose)
+
+    # ----------------------------------------------------------------- solve
+
+    def solve(self) -> Solution:
+        if self._num_variables == 0:
+            raise ValueError("CuOptSolver: initialize() must be called before solve().")
+        if self._objective is None:
+            raise ValueError("CuOptSolver: set_objective() must be called before solve().")
+
+        import time as _time
+
+        n_vars = self._num_variables
+        n_cons = len(self._constraint_buf)
+
+        # Objective vector
+        obj_coefs = np.zeros(n_vars, dtype=np.float64)
+        raw = self._objective.get_coefficients()
+        if hasattr(raw, "items"):
+            for vi, c in raw.items():
+                obj_coefs[vi] = c
+        else:
+            # Sequence form: index → coefficient by position
+            for vi, c in enumerate(list(raw)):
+                obj_coefs[vi] = c
+        # ilpy may report a constant on the objective; cuOpt has no
+        # objective-constant parameter, so we capture it and add it to the
+        # objective value we return.
+        obj_constant = float(self._objective.get_constant())
+
+        # Constraint matrix (CSR) + row bounds
+        if n_cons > 0:
+            rows: list[int] = []
+            cols: list[int] = []
+            vals: list[float] = []
+            rels = np.empty(n_cons, dtype=np.int32)
+            rhs = np.empty(n_cons, dtype=np.float64)
+            for ri, c in enumerate(self._constraint_buf):
+                for vi, v in c.get_coefficients().items():
+                    rows.append(ri)
+                    cols.append(vi)
+                    vals.append(v)
+                rels[ri] = int(c.get_relation())
+                rhs[ri] = c.get_value()
+            A = csr_matrix(
+                (
+                    np.asarray(vals, dtype=np.float64),
+                    (
+                        np.asarray(rows, dtype=np.int64),
+                        np.asarray(cols, dtype=np.int64),
+                    ),
+                ),
+                shape=(n_cons, n_vars),
+            )
+            row_lb = np.empty(n_cons, dtype=np.float64)
+            row_ub = np.empty(n_cons, dtype=np.float64)
+            le = rels == int(Relation.LessEqual)
+            eq = rels == int(Relation.Equal)
+            ge = rels == int(Relation.GreaterEqual)
+            row_lb[le] = -INF
+            row_ub[le] = rhs[le]
+            row_lb[eq] = rhs[eq]
+            row_ub[eq] = rhs[eq]
+            row_lb[ge] = rhs[ge]
+            row_ub[ge] = INF
+        else:
+            # Empty constraint set: build a 0×n_vars matrix to keep cuOpt happy.
+            A = csr_matrix((n_cons, n_vars), dtype=np.float64)
+            row_lb = np.zeros(0, dtype=np.float64)
+            row_ub = np.zeros(0, dtype=np.float64)
+
+        # Assemble DataModel
+        dm = data_model.DataModel()
+        dm.set_csr_constraint_matrix(A.data, A.indices, A.indptr)
+        dm.set_constraint_lower_bounds(row_lb)
+        dm.set_constraint_upper_bounds(row_ub)
+        dm.set_objective_coefficients(obj_coefs)
+        dm.set_variable_lower_bounds(self._var_lb)
+        dm.set_variable_upper_bounds(self._var_ub)
+        # cuOpt expects an array of single-char byte codes for var types
+        dm.set_variable_types(
+            np.asarray(self._var_types, dtype=object).astype(bytes)
+        )
+        dm.set_maximize(self._sense == Sense.Maximize)
+        self._last_dm = dm
+
+        # Settings
+        ss = SolverSettings()
+        if self._time_limit is not None:
+            ss.set_parameter("time_limit", str(self._time_limit))
+        if self._mip_gap_rel is not None:
+            ss.set_parameter("mip_relative_gap", str(self._mip_gap_rel))
+        if self._mip_gap_abs is not None:
+            ss.set_parameter("mip_absolute_gap", str(self._mip_gap_abs))
+        if self._verbose:
+            # cuOpt's log level varies by release; "log_level" is the
+            # documented public knob.
+            try:
+                ss.set_parameter("log_level", "1")
+            except Exception:
+                pass
+
+        # Optional escape hatch for advanced tuning. Same idiom as the
+        # OPS_CUOPT_EXTRA_PARAMS env var used in downstream consumers.
+        if os.environ.get("ILPY_CUOPT_HEURISTICS_ONLY") == "1":
+            try:
+                ss.set_parameter("mip_heuristics_only", "1")
+            except Exception:
+                pass
+        extra = os.environ.get("ILPY_CUOPT_EXTRA_PARAMS", "")
+        for kv in extra.split(","):
+            kv = kv.strip()
+            if not kv or "=" not in kv:
+                continue
+            k, v = kv.split("=", 1)
+            try:
+                ss.set_parameter(k.strip(), v.strip())
+            except Exception:
+                pass
+
+        # Solve
+        t0 = _time.monotonic()
+        sol = solver.Solve(dm, ss)
+        wall = _time.monotonic() - t0
+
+        native_status = int(sol.get_termination_status())
+        status = STATUS_MAP.get(native_status, SolverStatus.OTHER)
+
+        try:
+            primal = sol.get_primal_solution()
+            variable_values = list(np.asarray(primal, dtype=np.float64))
+        except Exception:
+            variable_values = [0.0] * n_vars
+
+        try:
+            obj_val = float(sol.get_primal_objective()) + obj_constant
+        except Exception:
+            obj_val = float("nan")
+
+        return Solution(
+            variable_values=variable_values,
+            objective_value=obj_val,
+            status=status,
+            time=wall,
+            native_status=sol.get_termination_reason(),
+        )
+
+    # --------------------------------------------------------- introspection
+
+    def native_model(self) -> Any:
+        return self._last_dm

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -107,9 +107,11 @@ def test_solve(preference: ilpy.Preference, case: Case) -> None:
         solution = ilpy.solve(**kwargs, preference=preference, on_event=mock)
     except NotImplementedError as e:
         # CuOpt is linear-only: quadratic objectives/constraints raise
-        # NotImplementedError in the backend. Treat that as an expected
-        # skip rather than a test failure.
-        pytest.xfail(f"{preference.name} backend does not support this case: {e}")
+        # NotImplementedError. For every other backend a NotImplementedError
+        # is a real regression, so only xfail on CuOpt and re-raise otherwise.
+        if preference != ilpy.Preference.CuOpt:
+            raise
+        pytest.xfail(f"CuOpt backend does not support this case: {e}")
     npt.assert_allclose(solution, expectation)
     assert mock.call_count > 0
     assert all(

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -103,7 +103,13 @@ def test_solve(preference: ilpy.Preference, case: Case) -> None:
     kwargs = case._asdict()
     expectation = kwargs.pop("expectation")
     mock = Mock()
-    solution = ilpy.solve(**kwargs, preference=preference, on_event=mock)
+    try:
+        solution = ilpy.solve(**kwargs, preference=preference, on_event=mock)
+    except NotImplementedError as e:
+        # CuOpt is linear-only: quadratic objectives/constraints raise
+        # NotImplementedError in the backend. Treat that as an expected
+        # skip rather than a test failure.
+        pytest.xfail(f"{preference.name} backend does not support this case: {e}")
     npt.assert_allclose(solution, expectation)
     assert mock.call_count > 0
     assert all(

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -39,12 +39,21 @@ try:
 except Exception as e:
     gr_marks.append(pytest.mark.xfail(reason=f"Gurobi restricted error: {e}"))
 
+# CuOpt requires the cuopt-cu12 wheel AND a visible CUDA device. Mark
+# xfail when either is absent so the suite runs everywhere.
+cuopt_marks = []
+try:
+    create_solver_backend(ilpy.Preference.CuOpt)
+except Exception as e:
+    cuopt_marks.append(pytest.mark.xfail(reason=f"cuOpt unavailable: {e}"))
+
 PREFS = [
     pytest.param(ilpy.Preference.Scip, id="scip"),
     pytest.param(ilpy.Preference.Gurobi, marks=gu_marks, id="gurobi"),
     pytest.param(
         ilpy.Preference.GurobiRestricted, marks=gr_marks, id="gurobi-restricted"
     ),
+    pytest.param(ilpy.Preference.CuOpt, marks=cuopt_marks, id="cuopt"),
 ]
 
 
@@ -202,6 +211,12 @@ def test_non_convex_quadratic(preference: ilpy.Preference) -> None:
     obj.set_quadratic_coefficient(0, 0, -1)  # quadratic term (-x^2)
 
     solver = ilpy.Solver(1, ilpy.VariableType.Continuous, preference=preference)
+    if preference == ilpy.Preference.CuOpt:
+        # CuOpt is a linear MIP solver; QP/MIQP is documented as
+        # NotImplementedError on this backend.
+        with pytest.raises(NotImplementedError):
+            solver.set_objective(obj)
+        return
     solver.set_objective(obj)
 
     constraint = ilpy.Constraint()


### PR DESCRIPTION
## Summary

Adds NVIDIA cuOpt (https://developer.nvidia.com/cuopt) as a new ilpy solver backend, accessed via `Preference.CuOpt`. cuOpt is an Apache-2.0 licensed GPU-accelerated MIP/LP solver — a useful open-license alternative to Gurobi for very large MIPs.

On cell-tracking ILPs in the multi-megavariable range, cuOpt reaches Optimal within minutes on a single GPU on problems where single-threaded SCIP doesn't finish within hour-budgets. Validated against a Gurobi-completed reference: variable values agree to within rounding error.

## Design

- New `Preference.CuOpt` enum value. **Opt-in only** — not included in `Preference.Any`, since the backend needs a CUDA device and the `cuopt-cu12` wheel from `pypi.nvidia.com`.
- `solver_backends/_cuopt.py` (new module). Buffers state from the standard `SolverBackend` API (`initialize` / `set_objective` / `set_constraints` / `add_constraint` / `set_timeout` / `set_optimality_gap` / `set_num_threads` / `set_verbose`) until `solve()` is called, then materialises a cuOpt `DataModel` / `SolverSettings` and dispatches a synchronous GPU solve.
- Status mapping: cuOpt `termination_status` (Optimal / Infeasible / Unbounded / TimeLimit / IterationLimit / Numerical / PrimalFeasible) → ilpy `SolverStatus`.
- `pyproject.toml`: new `[cuopt]` optional-dependencies group pulling `cuopt-cu12` + numpy + scipy. The wheel lives on the NVIDIA index, so install as:
  ```
  pip install --extra-index-url https://pypi.nvidia.com 'ilpy[cuopt]'
  ```
- `tests/test_solvers.py`: cuOpt added to the `PREFS` parametrize list with an `xfail` mark that fires when `cuopt-cu12` or CUDA aren't available, so the suite runs everywhere. The non-convex-quadratic smoke test expects `NotImplementedError` on the cuopt backend.
- `ilpy.CuOpt` module-level convenience (matches the existing `ilpy.Gurobi` / `ilpy.Scip` shortcuts).

## Limitations

cuOpt is a linear MIP/LP solver. Quadratic objectives and quadratic constraints raise `NotImplementedError`; QP / MIQP / QCP / MIQCP problems must continue to use SCIP or Gurobi.

## Optional env-var escape hatches

For tuning cuOpt on very large MIPs (off by default, not part of the public API):

- `ILPY_CUOPT_TIME_LIMIT=N` — wall-clock cap in seconds. Precedence: env var wins over the `set_timeout()` value the caller passed (useful when the solver is built deep inside third-party code that hardcodes a generous timeout).
- `ILPY_CUOPT_HEURISTICS_ONLY=1` — `mip_heuristics_only=1` (skip B&B, primal heuristics only).
- `ILPY_CUOPT_EXTRA_PARAMS=k1=v1,k2=v2` — arbitrary `SolverSettings` parameters.

Documented inline in `_cuopt.py`. Empirically, for cell-tracking-shaped MIPs on `cuopt-cu12 26.4.x` the Papilo presolve has a ~91 s fixed cost, so `time_limit < ~120 s` typically returns trivial primals; ~240 s is a safe default for problems in that size class.

## Validation

Cell-tracking ILPs on `ops0042_20250520` (3 wells of cell-tracking microscopy data, on 1× NVIDIA RTX Pro 6000 Blackwell, 16 CPU). Each well's ILP has roughly 2 M nodes and 1–4 M candidate edges → 3–6 M binary variables in the MIP.

Solver config: `mip_heuristics_only=1`, `time_limit=240 s`, `mip_gap=0.05`. All 3 wells reach Optimal in ~15 min each. Variable values match a Gurobi-completed reference within rounding error.

| Well | Status | Selected nodes | Selected edges | Approx. wall |
|---|---|---|---|---|
| A/1 | Optimal (gap 1e-6) | 2,654,866 | 1,989,249 | ~15 min |
| A/2 | Optimal | 2,209,275 | 1,544,059 | ~15 min |
| A/3 | Optimal | 1,695,162 | 1,030,245 | ~15 min |

(Selected edges = MIP solution, not candidate-graph edges.)

Earlier full-B&B sweep on a dumped instance of similar size showed `heuristics_only=1` was the single biggest knob: ~5 min to Optimal vs 30–72 min with full B&B at the same gap. On the same instance, single-threaded SCIP didn't finish within a 10 h budget.

## Tests

`pytest tests/test_solvers.py` passes with and without `cuopt-cu12` installed. When cuOpt isn't available the cuOpt-only parametrize values `xfail`; the non-cuOpt suite is unaffected.

## Downstream consumers

This branch is currently pinned via `[tool.uv.sources]` in [czbiohub-sf/ops_monorepo#15](https://github.com/czbiohub-sf/ops_monorepo/pull/15) and validated end-to-end against the open cell-tracking pipeline at [royerlab/ops_process#97](https://github.com/royerlab/ops_process/pull/97) and [royerlab/hoct_inference#5](https://github.com/royerlab/hoct_inference/pull/5). The fork pin will be dropped once a release containing `Preference.CuOpt` is on PyPI; happy to iterate on review feedback before that migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)